### PR TITLE
Add missing value checks

### DIFF
--- a/spec/low_level_spec.rb
+++ b/spec/low_level_spec.rb
@@ -1,35 +1,35 @@
 require "scale"
 
 describe Scale::Types::FixedWidthUInt do
-  it "shoud encode u8 right" do
+  it "should encode u8 right" do
     scale_bytes = Scale::Bytes.new("0x45")
     o = Scale::Types::U8.decode scale_bytes
     expect(o.value).to eql(69)
     expect(o.encode).to eql("45")
   end
 
-  it "shoud encode u16 right" do
+  it "should encode u16 right" do
     scale_bytes = Scale::Bytes.new("0x2a00")
     o = Scale::Types::U16.decode scale_bytes
     expect(o.value).to eql(42)
     expect(o.encode).to eql("2a00")
   end
 
-  it "shoud encode u32 right" do
+  it "should encode u32 right" do
     scale_bytes = Scale::Bytes.new("0xffffff00")
     o = Scale::Types::U32.decode scale_bytes
     expect(o.value).to eql(16777215)
     expect(o.encode).to eql("ffffff00")
   end
 
-  it "shoud encode u64 right" do
+  it "should encode u64 right" do
     scale_bytes = Scale::Bytes.new("0x00e40b5403000000")
     o = Scale::Types::U64.decode scale_bytes
     expect(o.value).to eql(14294967296)
     expect(o.encode).to eql("00e40b5403000000")
   end
 
-  it "shoud encode u128 right" do
+  it "should encode u128 right" do
     scale_bytes = Scale::Bytes.new("0x0bfeffffffffffff0000000000000000")
     o = Scale::Types::U128.decode scale_bytes
     expect(o.value).to eql(18446744073709551115)

--- a/spec/low_level_spec.rb
+++ b/spec/low_level_spec.rb
@@ -131,12 +131,14 @@ describe Scale::Types::Vector do
   it "should encode vector u8 right" do
     scale_bytes = Scale::Bytes.new("0x0c003afe")
     o = Scale::Types::VectorU8.decode scale_bytes
+    expect(o.value.map(&:value)).to eql([0, 58, 254])
     expect(o.encode).to eql("0c003afe")
   end
 
   it "should encode vector u8 right" do
     scale_bytes = Scale::Bytes.new("0x0c003afe")
     o = type("Vec<U8>").decode scale_bytes
+    expect(o.value.map(&:value)).to eql([0, 58, 254])
     expect(o.encode).to eql("0c003afe")
   end
 end
@@ -145,6 +147,23 @@ describe Scale::Types::Struct do
   it "should encode student right" do
     scale_bytes = Scale::Bytes.new("0x0100000045000045")
     o = Scale::Types::Student.decode scale_bytes
+
+    [
+      [o.age, Scale::Types::U32],
+      [o.grade, Scale::Types::U8],
+      [o.courses_number, Scale::Types::OptionU32],
+      [o.int_or_bool, Scale::Types::IntOrBool]
+    ]
+      .map { |(actual, expectation)| expect(actual.class).to eql(expectation) }
+
+    [
+      [o.age, 1],
+      [o.grade, 69],
+      [o.courses_number, nil],
+      [o.int_or_bool.value, 69]
+    ]
+      .map { |(actual, expectation)| expect(actual.value).to eql(expectation) }
+
     expect(o.encode).to eql("0100000045000045")
   end
 end
@@ -154,9 +173,11 @@ describe Scale::Types::Enum do
     scale_bytes = Scale::Bytes.new("0x0101")
     o = Scale::Types::IntOrBool.decode scale_bytes
     expect(o.encode).to eql("0101")
+    expect(o.value.value).to eql(true)
 
     scale_bytes = Scale::Bytes.new("0x002a")
     o = Scale::Types::IntOrBool.decode scale_bytes
     expect(o.encode).to eql("002a")
+    expect(o.value.value).to eql(42)
   end
 end

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,7 +1,7 @@
 require "scale"
 
 describe Scale::Types::Student do
-  it "shoud decode from a scale hex string" do
+  it "should decode from a scale hex string" do
     # 0x 01000000 45 00 0045
     scale_bytes = Scale::Bytes.new("0x0100000045000045")
     s1 = Scale::Types::Student.decode scale_bytes


### PR DESCRIPTION
Some encode/decode tests in `spec/low_level_spec.rb` were missing Ruby-native value checks. 