### PR TITLE
Rust FFI for testing encoding across Ruby/Rust implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "SCALE-testing-interface"
 version = "0.1.0"
 authors = ["Robert Hambrock <robert@web3.foundation>"]
 
+[dependencies]
+parity-scale-codec = { version = "1.2.0" }
+
 [lib]
 name = "scale_ffi"
 crate-type = ["dylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "SCALE-testing-interface"
+version = "0.1.0"
+authors = ["Robert Hambrock <robert@web3.foundation>"]
+
+[lib]
+name = "scale_ffi"
+crate-type = ["dylib"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in scale.gemspec
 gemspec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+ifeq ($(shell uname),Darwin)
+    EXT := dylib
+else
+    EXT := so
+endif
+
+all: target/debug/libvector_ffi.$(EXT)
+
+target/debug/libvector_ffi.$(EXT): src/lib.rs Cargo.toml
+	cargo build
+
+clean:
+	rm -rf target

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ scale.rb now support types:
 ## Running tests
 
 1. Download or clone the code to local, and enter the code root directory
-2. Run all tests
+2. If rust is installed on your system (for instance, `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`), call `make` to build the FFI library
+3. Run all tests
 
 ```
 rspec
 ```
 
-2. Run low level format tests
+To run only low level format tests, call
 
 ```
 rspec spec/low_level_spec.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
-require "bundler/gem_tasks"
-task :default => :spec
+require 'bundler/gem_tasks'
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "scale"
+require 'bundler/setup'
+require 'scale'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-require "pry"
+require 'pry'
 Pry.start
 
 # require "irb"

--- a/lib/metadata/metadata.rb
+++ b/lib/metadata/metadata.rb
@@ -1,24 +1,23 @@
 module Scale
   module Types
-
     class Metadata
       include SingleValue
       def self.decode(scale_bytes)
         bytes = scale_bytes.get_next_bytes(4)
         if bytes.bytes_to_utf8 == 'meta'
-          metadata_v_name = type_of("Enum", enum_values: [
-            "Scale::Types::MetadataV0", 
-            "Scale::Types::MetadataV1", 
-            "Scale::Types::MetadataV2", 
-            "Scale::Types::MetadataV3",
-            "Scale::Types::MetadataV4",
-            "Scale::Types::MetadataV5",
-            "Scale::Types::MetadataV6",
-            "Scale::Types::MetadataV7",
-            "Scale::Types::MetadataV8",
-            "Scale::Types::MetadataV9",
-            "Scale::Types::MetadataV10"
-          ]).decode(scale_bytes).value
+          metadata_v_name = type_of('Enum', enum_values: [
+                                      'Scale::Types::MetadataV0',
+                                      'Scale::Types::MetadataV1',
+                                      'Scale::Types::MetadataV2',
+                                      'Scale::Types::MetadataV3',
+                                      'Scale::Types::MetadataV4',
+                                      'Scale::Types::MetadataV5',
+                                      'Scale::Types::MetadataV6',
+                                      'Scale::Types::MetadataV7',
+                                      'Scale::Types::MetadataV8',
+                                      'Scale::Types::MetadataV9',
+                                      'Scale::Types::MetadataV10'
+                                    ]).decode(scale_bytes).value
 
           Metadata.new(metadata_v_name.constantize.decode(scale_bytes).value)
         end
@@ -38,19 +37,19 @@ module Scale
 
         has_storage = Bool.decode(scale_bytes).value
         if has_storage
-          storages = type_of("Vec<MetadataModuleStorage>").decode(scale_bytes).value
+          storages = type_of('Vec<MetadataModuleStorage>').decode(scale_bytes).value
           result[:storage] = storages.map(&:value)
         end
 
         has_calls = Bool.decode(scale_bytes).value
         if has_calls
-          calls = type_of("Vec<MetadataModuleCall>").decode(scale_bytes).value
+          calls = type_of('Vec<MetadataModuleCall>').decode(scale_bytes).value
           result[:calls] = calls.map(&:value)
         end
 
         has_events = Bool.decode(scale_bytes).value
         if has_events
-          events = type_of("Vec<MetadataModuleEvent>").decode(scale_bytes).value
+          events = type_of('Vec<MetadataModuleEvent>').decode(scale_bytes).value
           result[:events] = events.map(&:value)
         end
 
@@ -61,29 +60,28 @@ module Scale
     class MetadataModuleStorage
       include SingleValue
       def self.decode(scale_bytes)
-
         result = {
           name: String.decode(scale_bytes).value,
-          modifier: type_of("Enum", enum_values: ["Optional", "Default"]).decode(scale_bytes).value
+          modifier: type_of('Enum', enum_values: %w[Optional Default]).decode(scale_bytes).value
         }
 
         is_key_value = Bool.decode(scale_bytes).value
-        if is_key_value
-          result[:type] = {
-            Map: {
-              key: adjust(String.decode(scale_bytes).value),
-              value: adjust(String.decode(scale_bytes).value),
-              linked: Bool.decode(scale_bytes).value
-            }
-          }
-        else
-          result[:type] = {
-            Plain: adjust(String.decode(scale_bytes).value)
-          }
-        end
+        result[:type] = if is_key_value
+                          {
+                            Map: {
+                              key: adjust(String.decode(scale_bytes).value),
+                              value: adjust(String.decode(scale_bytes).value),
+                              linked: Bool.decode(scale_bytes).value
+                            }
+                          }
+                        else
+                          {
+                            Plain: adjust(String.decode(scale_bytes).value)
+                          }
+                        end
 
         result[:fallback] = Hex.decode(scale_bytes).value
-        result[:documentation] = type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+        result[:documentation] = type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
 
         MetadataModuleStorage.new(result)
       end
@@ -94,8 +92,8 @@ module Scale
       def self.decode(scale_bytes)
         result = {}
         result[:name] = String.decode(scale_bytes).value
-        result[:args] = type_of("Vec<MetadataModuleCallArgument>").decode(scale_bytes).value.map(&:value)
-        result[:documentation] = type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+        result[:args] = type_of('Vec<MetadataModuleCallArgument>').decode(scale_bytes).value.map(&:value)
+        result[:documentation] = type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
         MetadataModuleCall.new(result)
       end
     end
@@ -116,12 +114,11 @@ module Scale
       def self.decode(scale_bytes)
         result = {}
         result[:name] = String.decode(scale_bytes).value
-        result[:args] = type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
-        result[:documentation] = type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+        result[:args] = type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
+        result[:documentation] = type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
 
         MetadataModuleEvent.new(result)
       end
     end
-
   end
 end

--- a/lib/metadata/metadata_v10.rb
+++ b/lib/metadata/metadata_v10.rb
@@ -1,12 +1,11 @@
 module Scale
   module Types
-
     class MetadataV10
       include SingleValue
       def self.decode(scale_bytes)
-        modules = type_of("Vec<MetadataV8Module>").decode(scale_bytes).value;
+        modules = type_of('Vec<MetadataV8Module>').decode(scale_bytes).value
         result = {
-          magicNumber: 1635018093,
+          magicNumber: 1_635_018_093,
           metadata: {
             V10: {
               modules: modules.map(&:value)
@@ -17,6 +16,5 @@ module Scale
         MetadataV10.new(result)
       end
     end
-
   end
 end

--- a/lib/metadata/metadata_v3.rb
+++ b/lib/metadata/metadata_v3.rb
@@ -1,12 +1,11 @@
 module Scale
   module Types
-
     class MetadataV3
       include SingleValue
       def self.decode(scale_bytes)
-        modules = type_of("Vec<MetadataModule>").decode(scale_bytes).value;
+        modules = type_of('Vec<MetadataModule>').decode(scale_bytes).value
         result = {
-          magicNumber: 1635018093,
+          magicNumber: 1_635_018_093,
           metadata: {
             V3: {
               modules: modules.map(&:value)
@@ -17,6 +16,5 @@ module Scale
         MetadataV3.new(result)
       end
     end
-
   end
 end

--- a/lib/metadata/metadata_v7.rb
+++ b/lib/metadata/metadata_v7.rb
@@ -1,12 +1,11 @@
 module Scale
   module Types
-
     class MetadataV7
       include SingleValue
       def self.decode(scale_bytes)
-        modules = type_of("Vec<MetadataV7Module>").decode(scale_bytes).value;
+        modules = type_of('Vec<MetadataV7Module>').decode(scale_bytes).value
         result = {
-          magicNumber: 1635018093,
+          magicNumber: 1_635_018_093,
           metadata: {
             V7: {
               modules: modules.map(&:value)
@@ -24,7 +23,7 @@ module Scale
         name = String.decode(scale_bytes).value
 
         result = {
-          name: name,
+          name: name
         }
 
         has_storage = Bool.decode(scale_bytes).value
@@ -36,17 +35,17 @@ module Scale
 
         has_calls = Bool.decode(scale_bytes).value
         if has_calls
-          calls = type_of("Vec<MetadataModuleCall>").decode(scale_bytes).value
+          calls = type_of('Vec<MetadataModuleCall>').decode(scale_bytes).value
           result[:calls] = calls.map(&:value)
         end
 
         has_events = Bool.decode(scale_bytes).value
         if has_events
-          events = type_of("Vec<MetadataModuleEvent>").decode(scale_bytes).value
+          events = type_of('Vec<MetadataModuleEvent>').decode(scale_bytes).value
           result[:events] = events.map(&:value)
         end
 
-        result[:constants] = type_of("Vec<MetadataV7ModuleConstants>").decode(scale_bytes).value.map(&:value)
+        result[:constants] = type_of('Vec<MetadataV7ModuleConstants>').decode(scale_bytes).value.map(&:value)
 
         MetadataV7Module.new(result)
       end
@@ -56,7 +55,7 @@ module Scale
       include SingleValue
       def self.decode(scale_bytes)
         prefix = String.decode(scale_bytes).value
-        items = type_of("Vec<MetadataV7ModuleStorageEntry>").decode(scale_bytes).value.map(&:value)
+        items = type_of('Vec<MetadataV7ModuleStorageEntry>').decode(scale_bytes).value.map(&:value)
         result = {
           prefix: prefix,
           items: items
@@ -71,14 +70,14 @@ module Scale
       def self.decode(scale_bytes)
         result = {
           name: String.decode(scale_bytes).value,
-          modifier: type_of("Enum", enum_values: ["Optional", "Default"]).decode(scale_bytes).value
+          modifier: type_of('Enum', enum_values: %w[Optional Default]).decode(scale_bytes).value
         }
-        storage_function_type = type_of("Enum", enum_values: ["Plain", "Map", "DoubleMap"]).decode(scale_bytes).value
-        if storage_function_type == "Plain"
+        storage_function_type = type_of('Enum', enum_values: %w[Plain Map DoubleMap]).decode(scale_bytes).value
+        if storage_function_type == 'Plain'
           result[:type] = {
             Plain: adjust(String.decode(scale_bytes).value)
           }
-        elsif storage_function_type == "Map"
+        elsif storage_function_type == 'Map'
           result[:type] = {
             Map: {
               hasher: StorageHasher.decode(scale_bytes).value,
@@ -87,7 +86,7 @@ module Scale
               linked: Bool.decode(scale_bytes).value
             }
           }
-        elsif storage_function_type == "DoubleMap"
+        elsif storage_function_type == 'DoubleMap'
           result[:type] = {
             DoubleMap: {
               hasher: StorageHasher.decode(scale_bytes).value,
@@ -100,7 +99,7 @@ module Scale
         end
 
         result[:fallback] = Hex.decode(scale_bytes).value
-        result[:docs] = type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+        result[:docs] = type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
 
         MetadataV7ModuleStorageEntry.new(result)
       end
@@ -113,11 +112,10 @@ module Scale
           name: String.decode(scale_bytes).value,
           type: String.decode(scale_bytes).value, # convert
           value: Hex.decode(scale_bytes).value,
-          docs: type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+          docs: type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
         }
         MetadataV7ModuleConstants.new result
       end
     end
-
   end
 end

--- a/lib/metadata/metadata_v8.rb
+++ b/lib/metadata/metadata_v8.rb
@@ -1,12 +1,11 @@
 module Scale
   module Types
-
     class MetadataV8
       include SingleValue
       def self.decode(scale_bytes)
-        modules = type_of("Vec<MetadataV8Module>").decode(scale_bytes).value;
+        modules = type_of('Vec<MetadataV8Module>').decode(scale_bytes).value
         result = {
-          magicNumber: 1635018093,
+          magicNumber: 1_635_018_093,
           metadata: {
             V8: {
               modules: modules.map(&:value)
@@ -24,7 +23,7 @@ module Scale
         name = String.decode(scale_bytes).value
 
         result = {
-          name: name,
+          name: name
         }
 
         has_storage = Bool.decode(scale_bytes).value
@@ -36,18 +35,18 @@ module Scale
 
         has_calls = Bool.decode(scale_bytes).value
         if has_calls
-          calls = type_of("Vec<MetadataModuleCall>").decode(scale_bytes).value
+          calls = type_of('Vec<MetadataModuleCall>').decode(scale_bytes).value
           result[:calls] = calls.map(&:value)
         end
 
         has_events = Bool.decode(scale_bytes).value
         if has_events
-          events = type_of("Vec<MetadataModuleEvent>").decode(scale_bytes).value
+          events = type_of('Vec<MetadataModuleEvent>').decode(scale_bytes).value
           result[:events] = events.map(&:value)
         end
 
-        result[:constants] = type_of("Vec<MetadataV7ModuleConstants>").decode(scale_bytes).value.map(&:value)
-        result[:errors] = type_of("Vec<MetadataModuleError>").decode(scale_bytes).value.map(&:value)
+        result[:constants] = type_of('Vec<MetadataV7ModuleConstants>').decode(scale_bytes).value.map(&:value)
+        result[:errors] = type_of('Vec<MetadataModuleError>').decode(scale_bytes).value.map(&:value)
 
         MetadataV8Module.new(result)
       end
@@ -58,12 +57,11 @@ module Scale
       def self.decode(scale_bytes)
         result = {
           name: String.decode(scale_bytes).value,
-          docs: type_of("Vec<String>").decode(scale_bytes).value.map(&:value)
+          docs: type_of('Vec<String>').decode(scale_bytes).value.map(&:value)
         }
 
         MetadataModuleError.new(result)
       end
     end
-
   end
 end

--- a/lib/metadata/metadata_v9.rb
+++ b/lib/metadata/metadata_v9.rb
@@ -1,12 +1,11 @@
 module Scale
   module Types
-
     class MetadataV9
       include SingleValue
       def self.decode(scale_bytes)
-        modules = type_of("Vec<MetadataV8Module>").decode(scale_bytes).value;
+        modules = type_of('Vec<MetadataV8Module>').decode(scale_bytes).value
         result = {
-          magicNumber: 1635018093,
+          magicNumber: 1_635_018_093,
           metadata: {
             V9: {
               modules: modules.map(&:value)
@@ -17,6 +16,5 @@ module Scale
         MetadataV9.new(result)
       end
     end
-
   end
 end

--- a/lib/scale/version.rb
+++ b/lib/scale/version.rb
@@ -1,3 +1,3 @@
 module Scale
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'.freeze
 end

--- a/scale.gemspec
+++ b/scale.gemspec
@@ -1,43 +1,42 @@
-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "scale/version"
+require 'scale/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "scale.rb"
+  spec.name          = 'scale.rb'
   spec.version       = Scale::VERSION
-  spec.authors       = ["Wu Minzhe"]
-  spec.email         = ["wuminzhe@gmail.com"]
+  spec.authors       = ['Wu Minzhe']
+  spec.email         = ['wuminzhe@gmail.com']
 
-  spec.summary       = %q{Ruby implementation of the parity SCALE data format}
-  spec.description   = %q{SCALE - Simple Concatenating Aggregated Little Endians}
-  spec.homepage      = "https://github.com/itering/scale.rb"
-  spec.license       = "MIT"
+  spec.summary       = 'Ruby implementation of the parity SCALE data format'
+  spec.description   = 'SCALE - Simple Concatenating Aggregated Little Endians'
+  spec.homepage      = 'https://github.com/itering/scale.rb'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://rubygems.org"
+    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-    spec.metadata["homepage_uri"] = spec.homepage
+    spec.metadata['homepage_uri'] = spec.homepage
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "substrate_common.rb", "~> 0.1.3"
+  spec.add_dependency 'substrate_common.rb', '~> 0.1.3'
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.2'
 end

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -7,21 +7,21 @@ require 'ffi'
 module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
-  attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :void
-  attach_function :byte_string_literal_parse_u8, %i[pointer int uint8], :void
-  attach_function :byte_string_literal_parse_bool, %i[pointer int bool], :void
+  attach_function :parse_u64, %i[pointer int uint64], :void
+  attach_function :parse_u8, %i[pointer int uint8], :void
+  attach_function :parse_bool, %i[pointer int bool], :void
 end
 
 parse_u64 = proc { |vec_c, value|
-  Rust.byte_string_literal_parse_u64(vec_c, vec_c.size, value)
+  Rust.parse_u64(vec_c, vec_c.size, value)
 }
 
 parse_u8 = proc { |vec_c, value|
-  Rust.byte_string_literal_parse_u8(vec_c, vec_c.size, value)
+  Rust.parse_u8(vec_c, vec_c.size, value)
 }
 
 parse_bool = proc { |vec_c, value|
-  Rust.byte_string_literal_parse_bool(vec_c, vec_c.size, value)
+  Rust.parse_bool(vec_c, vec_c.size, value)
 }
 
 def check_against_specification(encoded, expectation)

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -49,25 +49,35 @@ end
 def parse_via_ffi(value, encoding, ffi_function, expectation)
   encoded = encoding.new(value).encode
   check_against_specification(encoded, expectation)
-  puts encoded
+  puts "encoded: #{encoded} "
   vec = Scale::Bytes.new('0x' + encoded).bytes
-  puts vec
+  puts "vec: #{vec} "
 
   vec_c = FFI::MemoryPointer.new(:int8, vec.size)
   vec_c.write_array_of_int8 vec
   ffi_function.call(vec_c, value)
 end
 
+# U64
+puts "\nU64 tests"
 parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')
 
+# U32
+puts "\nU32 tests"
 parse_via_ffi(16_777_215, Scale::Types::U32, parse_u32, 'ffffff00')
 parse_via_ffi(4_294_967_041, Scale::Types::U32, parse_u32, '01ffffff')
 
+# U8
+puts "\nU8 tests"
 parse_via_ffi(69, Scale::Types::U8, parse_u8, '45')
 
+# Bool
+puts "\nBool tests"
 parse_via_ffi(true, Scale::Types::Bool, parse_bool, '01')
 parse_via_ffi(false, Scale::Types::Bool, parse_bool, '00')
 
+# Optional U32
+puts "\nOptional U32 tests"
 parse_via_ffi(nil, Scale::Types::OptionU32, parse_opt_u32, '00')
 parse_via_ffi(
   Scale::Types::U32.new(16_777_215),

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -42,9 +42,9 @@ def check_against_specification(encoded, expectation)
   end
 end
 
-def parse_via_ffi(value, encoding, expectation)
+def parse_via_ffi(value, encoding)
   encoded = encoding.new(value).encode
-  check_against_specification(encoded, expectation)
+  # check_against_specification(encoded, expectation)
   puts "encoded: #{encoded} "
   vec = Scale::Bytes.new('0x' + encoded).bytes
   puts "vec: #{vec} "
@@ -54,28 +54,34 @@ def parse_via_ffi(value, encoding, expectation)
   parse_type(encoding).call(vec_c, value)
 end
 
+def parse_via_ffi_plus_spec(value, encoding, expecation)
+  encoded = encoding.new(value).encode
+  check_against_specification(encoded, expecation)
+  parse_via_ffi(value, encoding)
+end
+
 # U64
 puts "\nU64 tests"
-parse_via_ffi(14_294_967_296, Scale::Types::U64, '00e40b5403000000')
+parse_via_ffi_plus_spec(14_294_967_296, Scale::Types::U64, '00e40b5403000000')
 
 # U32
 puts "\nU32 tests"
-parse_via_ffi(16_777_215, Scale::Types::U32, 'ffffff00')
-parse_via_ffi(4_294_967_041, Scale::Types::U32, '01ffffff')
+parse_via_ffi_plus_spec(16_777_215, Scale::Types::U32, 'ffffff00')
+parse_via_ffi_plus_spec(4_294_967_041, Scale::Types::U32, '01ffffff')
 
 # U8
 puts "\nU8 tests"
-parse_via_ffi(69, Scale::Types::U8, '45')
+parse_via_ffi_plus_spec(69, Scale::Types::U8, '45')
 
 # Bool
 puts "\nBool tests"
-parse_via_ffi(true, Scale::Types::Bool, '01')
-parse_via_ffi(false, Scale::Types::Bool, '00')
+parse_via_ffi_plus_spec(true, Scale::Types::Bool, '01')
+parse_via_ffi_plus_spec(false, Scale::Types::Bool, '00')
 
 # Optional U32
 puts "\nOptional U32 tests"
-parse_via_ffi(nil, Scale::Types::OptionU32, '00')
-parse_via_ffi(
+parse_via_ffi_plus_spec(nil, Scale::Types::OptionU32, '00')
+parse_via_ffi_plus_spec(
   Scale::Types::U32.new(16_777_215),
   Scale::Types::OptionU32,
   '01ffffff00'

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -12,6 +12,7 @@ module Rust
   attach_function :parse_u8, %i[pointer int uint8], :void
   attach_function :parse_bool, %i[pointer int bool], :void
   attach_function :parse_opt_u32, %i[pointer int uint32 bool], :void
+  attach_function :parse_opt_bool, %i[pointer int bool bool], :void
 end
 
 def parse_type(key)
@@ -29,6 +30,15 @@ def parse_type(key)
         Rust.parse_opt_u32(vec, vec.size, 0, false)
       else
         Rust.parse_opt_u32(vec, vec.size, val.value, true)
+      end
+    },
+
+    Scale::Types::OptionBool => proc { |vec, val|
+      if val.nil?
+        Rust.parse_opt_bool(vec, vec.size, false, false)
+      else
+        puts "value: #{val}"
+        Rust.parse_opt_bool(vec, vec.size, val, true)
       end
     }
   }[key]
@@ -52,6 +62,9 @@ def parse_via_ffi(value, encoding)
   vec_c.write_array_of_int8 vec
   parse_type(encoding).call(vec_c, value)
 end
+
+# everything beyond this point should ultimately be moved to types_spec.rb or
+# removed
 
 def parse_via_ffi_plus_spec(value, encoding, expecation)
   encoded = encoding.new(value).encode

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -1,27 +1,25 @@
 # coding: utf-8
 
 require 'scale'
+require_relative './types_for_test.rb'
 require 'ffi'
 
 module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
-  attach_function :vector_input, %i[pointer int], :int
+  attach_function :byte_string_literal_parse, %i[pointer int], :bool
 end
 
-# vec = [7, 8, 9]
-# vec_c = FFI::MemoryPointer.new(:int, vec.size)
-# vec_c.write_array_of_int vec
-# describe do
-#   it 'should return 1 regardless of input' do
-#     expect(Rust.vector_input(vec_c, vec.size)).to eql(1)
-#   end
-# end
+encoded_u64 = Scale::Types::U64.new(14_294_967_296).encode
+describe do
+  it 'encoding should match specification' do
+    expect(encoded_u64).to eql('00e40b5403000000')
+  end
+end
+vec = Scale::Bytes.new('0x' + encoded_u64).bytes
 
-scale_bytes = Scale::Bytes.new('0x45')
-# scale_bytes = Scale::Bytes.new('0x0c003afe')
-scale_bytes = Scale::Bytes.new('0x2a00')
-puts scale_bytes.bytes
-scale_bytes_c = FFI::MemoryPointer.new(48)
-scale_bytes_c.write_array_of_int scale_bytes.bytes
-Rust.vector_input(scale_bytes_c, 12)
+FFI::MemoryPointer.new(:int8, vec.size) do |vec_c|
+  vec_c.write_array_of_int8 vec
+  puts "vec_c: #{ vec_c }"
+  puts Rust.byte_string_literal_parse(vec_c, vec_c.size)
+end

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -16,27 +16,19 @@ end
 
 def parse_type(key)
   {
-    Scale::Types::U64 => proc { |vec_c, value|
-      Rust.parse_u64(vec_c, vec_c.size, value)
-    },
+    Scale::Types::U64 => proc { |vec, val| Rust.parse_u64(vec, vec.size, val) },
 
-    Scale::Types::U32 => proc { |vec_c, value|
-      Rust.parse_u32(vec_c, vec_c.size, value)
-    },
+    Scale::Types::U32 => proc { |vec, val| Rust.parse_u32(vec, vec.size, val) },
 
-    Scale::Types::U8 => proc { |vec_c, value|
-      Rust.parse_u8(vec_c, vec_c.size, value)
-    },
+    Scale::Types::U8 => proc { |vec, val| Rust.parse_u8(vec, vec.size, val) },
 
-    Scale::Types::Bool => proc { |vec_c, value|
-      Rust.parse_bool(vec_c, vec_c.size, value)
-    },
+    Scale::Types::Bool => proc { |vec, val| Rust.parse_bool(vec, vec.size, val) },
 
-    Scale::Types::OptionU32 => proc { |vec_c, value|
-      if value.nil?
-        Rust.parse_opt_u32(vec_c, vec_c.size, 0, false)
+    Scale::Types::OptionU32 => proc { |vec, val|
+      if val.nil?
+        Rust.parse_opt_u32(vec, vec.size, 0, false)
       else
-        Rust.parse_opt_u32(vec_c, vec_c.size, value.value, true)
+        Rust.parse_opt_u32(vec, vec.size, val.value, true)
       end
     }
   }[key]

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -1,0 +1,27 @@
+# coding: utf-8
+
+require 'scale'
+require 'ffi'
+
+module Rust
+  extend FFI::Library
+  ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
+  attach_function :vector_input, %i[pointer int], :int
+end
+
+# vec = [7, 8, 9]
+# vec_c = FFI::MemoryPointer.new(:int, vec.size)
+# vec_c.write_array_of_int vec
+# describe do
+#   it 'should return 1 regardless of input' do
+#     expect(Rust.vector_input(vec_c, vec.size)).to eql(1)
+#   end
+# end
+
+scale_bytes = Scale::Bytes.new('0x45')
+# scale_bytes = Scale::Bytes.new('0x0c003afe')
+scale_bytes = Scale::Bytes.new('0x2a00')
+puts scale_bytes.bytes
+scale_bytes_c = FFI::MemoryPointer.new(48)
+scale_bytes_c.write_array_of_int scale_bytes.bytes
+Rust.vector_input(scale_bytes_c, 12)

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -8,12 +8,17 @@ module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
   attach_function :parse_u64, %i[pointer int uint64], :void
+  attach_function :parse_u32, %i[pointer int uint32], :void
   attach_function :parse_u8, %i[pointer int uint8], :void
   attach_function :parse_bool, %i[pointer int bool], :void
 end
 
 parse_u64 = proc { |vec_c, value|
   Rust.parse_u64(vec_c, vec_c.size, value)
+}
+
+parse_u32 = proc { |vec_c, value|
+  Rust.parse_u32(vec_c, vec_c.size, value)
 }
 
 parse_u8 = proc { |vec_c, value|
@@ -45,6 +50,9 @@ def parse_via_ffi(value, encoding, ffi_function, expectation)
 end
 
 parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')
+
+parse_via_ffi(16_777_215, Scale::Types::U32, parse_u32, 'ffffff00')
+parse_via_ffi(4_294_967_041, Scale::Types::U32, parse_u32, '01ffffff')
 
 parse_via_ffi(69, Scale::Types::U8, parse_u8, '45')
 

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -7,7 +7,7 @@ require 'ffi'
 module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
-  attach_function :byte_string_literal_parse, %i[pointer int uint64], :bool
+  attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :bool
 end
 
 value = 14_294_967_296
@@ -23,7 +23,7 @@ puts vec
 FFI::MemoryPointer.new(:int8, vec.size) do |vec_c|
   vec_c.write_array_of_int8 vec
   puts "vec_c: #{vec_c}"
-  ffi_success = Rust.byte_string_literal_parse(vec_c, vec_c.size, value)
+  ffi_success = Rust.byte_string_literal_parse_u64(vec_c, vec_c.size, value)
   describe do
     it 'Rust implementation should decode to expected value' do
       expect(ffi_success).to eql(true)

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -45,9 +45,8 @@ end
 def parse_via_ffi(value, encoding)
   encoded = encoding.new(value).encode
   # check_against_specification(encoded, expectation)
-  puts "encoded: #{encoded} "
+  puts "\nencoded: #{encoded}, value: #{value}, type: #{encoding}"
   vec = Scale::Bytes.new('0x' + encoded).bytes
-  puts "vec: #{vec} "
 
   vec_c = FFI::MemoryPointer.new(:int8, vec.size)
   vec_c.write_array_of_int8 vec

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -9,6 +9,7 @@ module Rust
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
   attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :void
   attach_function :byte_string_literal_parse_u8, %i[pointer int uint8], :void
+  attach_function :byte_string_literal_parse_bool, %i[pointer int bool], :void
 end
 
 parse_u64 = proc { |vec_c, value|
@@ -17,6 +18,10 @@ parse_u64 = proc { |vec_c, value|
 
 parse_u8 = proc { |vec_c, value|
   Rust.byte_string_literal_parse_u8(vec_c, vec_c.size, value)
+}
+
+parse_bool = proc { |vec_c, value|
+  Rust.byte_string_literal_parse_bool(vec_c, vec_c.size, value)
 }
 
 def check_against_specification(encoded, expectation)
@@ -42,3 +47,6 @@ end
 parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')
 
 parse_via_ffi(69, Scale::Types::U8, parse_u8, '45')
+
+parse_via_ffi(true, Scale::Types::Bool, parse_bool, '01')
+parse_via_ffi(false, Scale::Types::Bool, parse_bool, '00')

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -7,8 +7,8 @@ require 'ffi'
 module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
-  attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :bool
-  attach_function :byte_string_literal_parse_u8, %i[pointer int uint8], :bool
+  attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :void
+  attach_function :byte_string_literal_parse_u8, %i[pointer int uint8], :void
 end
 
 parse_u64 = proc { |vec_c, value|
@@ -27,14 +27,6 @@ def check_against_specification(encoded, expectation)
   end
 end
 
-def check_against_value(ffi_success)
-  describe do
-    it 'Rust implementation should decode to expected value' do
-      expect(ffi_success).to eql(true)
-    end
-  end
-end
-
 def parse_via_ffi(value, encoding, ffi_function, expectation)
   encoded = encoding.new(value).encode
   check_against_specification(encoded, expectation)
@@ -44,8 +36,7 @@ def parse_via_ffi(value, encoding, ffi_function, expectation)
 
   vec_c = FFI::MemoryPointer.new(:int8, vec.size)
   vec_c.write_array_of_int8 vec
-  ffi_success = ffi_function.call(vec_c, value)
-  check_against_value(ffi_success)
+  ffi_function.call(vec_c, value)
 end
 
 parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -8,10 +8,15 @@ module Rust
   extend FFI::Library
   ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
   attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :bool
+  attach_function :byte_string_literal_parse_u8, %i[pointer int uint8], :bool
 end
 
 parse_u64 = proc { |vec_c, value|
   Rust.byte_string_literal_parse_u64(vec_c, vec_c.size, value)
+}
+
+parse_u8 = proc { |vec_c, value|
+  Rust.byte_string_literal_parse_u8(vec_c, vec_c.size, value)
 }
 
 def parse_via_ffi(value, encoding, ffi_function, expectation)
@@ -38,3 +43,5 @@ def parse_via_ffi(value, encoding, ffi_function, expectation)
 end
 
 parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')
+
+parse_via_ffi(69, Scale::Types::U8, parse_u8, '45')

--- a/spec/ffi_spec.rb
+++ b/spec/ffi_spec.rb
@@ -10,23 +10,31 @@ module Rust
   attach_function :byte_string_literal_parse_u64, %i[pointer int uint64], :bool
 end
 
-value = 14_294_967_296
-encoded_u64 = Scale::Types::U64.new(value).encode
-describe do
-  it 'encoding should match specification' do
-    expect(encoded_u64).to eql('00e40b5403000000')
-  end
-end
-vec = Scale::Bytes.new('0x' + encoded_u64).bytes
-puts vec
+parse_u64 = proc { |vec_c, value|
+  Rust.byte_string_literal_parse_u64(vec_c, vec_c.size, value)
+}
 
-FFI::MemoryPointer.new(:int8, vec.size) do |vec_c|
-  vec_c.write_array_of_int8 vec
-  puts "vec_c: #{vec_c}"
-  ffi_success = Rust.byte_string_literal_parse_u64(vec_c, vec_c.size, value)
+def parse_via_ffi(value, encoding, ffi_function, expectation)
+  encoded = encoding.new(value).encode
+  puts encoded
   describe do
-    it 'Rust implementation should decode to expected value' do
-      expect(ffi_success).to eql(true)
+    it 'encoding should match specification' do
+      expect(encoded).to eql(expectation)
+    end
+  end
+  vec = Scale::Bytes.new('0x' + encoded).bytes
+  puts vec
+
+  FFI::MemoryPointer.new(:int8, vec.size) do |vec_c|
+    vec_c.write_array_of_int8 vec
+    puts "vec_c: #{vec_c}"
+    ffi_success = ffi_function.call(vec_c, value)
+    describe do
+      it 'Rust implementation should decode to expected value' do
+        expect(ffi_success).to eql(true)
+      end
     end
   end
 end
+
+parse_via_ffi(14_294_967_296, Scale::Types::U64, parse_u64, '00e40b5403000000')

--- a/spec/types_for_test.rb
+++ b/spec/types_for_test.rb
@@ -1,6 +1,5 @@
 module Scale
   module Types
-
     class IntOrBool
       include Enum
       items Int: 'U8', Bool: 'Bool'
@@ -13,12 +12,12 @@ module Scale
 
     class OptionBool
       include Option
-      INNER_TYPE_STR = 'boolean'
+      INNER_TYPE_STR = 'boolean'.freeze
     end
 
     class OptionU32
       include Option
-      INNER_TYPE_STR = 'U32'
+      INNER_TYPE_STR = 'U32'.freeze
     end
 
     class Student
@@ -33,9 +32,7 @@ module Scale
 
     class TupleDoubleU8
       include Tuple
-      inner_types "U8", "U8"
+      inner_types 'U8', 'U8'
     end
-
   end
 end
-

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,16 +1,17 @@
 # coding: utf-8
 require 'scale'
 require_relative './types_for_test.rb'
+require_relative './ffi_spec.rb'
 
 module Scale
   module Types
     describe U8 do
       it 'should work correctly' do
         scale_bytes = Scale::Bytes.new('0x45')
-        # puts scale_bytes
         o = U8.decode scale_bytes
         expect(o.value).to eql(69)
         expect(o.encode).to eql('45')
+        parse_via_ffi(o.value, U8)
       end
     end
 

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -30,6 +30,7 @@ module Scale
         o = U32.decode scale_bytes
         expect(o.value).to eql(16_777_215)
         expect(o.encode).to eql('ffffff00')
+        parse_via_ffi(o.value, U32)
       end
     end
 
@@ -39,6 +40,7 @@ module Scale
         o = U64.decode scale_bytes
         expect(o.value).to eql(14_294_967_296)
         expect(o.encode).to eql('00e40b5403000000')
+        parse_via_ffi(o.value, U64)
       end
     end
 
@@ -57,11 +59,13 @@ module Scale
         o = Bool.decode scale_bytes
         expect(o.value).to eql(false)
         expect(o.encode).to eql('00')
+        parse_via_ffi(o.value, Bool)
 
         scale_bytes = Scale::Bytes.new('0x01')
         o = Bool.decode scale_bytes
         expect(o.value).to eql(true)
         expect(o.encode).to eql('01')
+        parse_via_ffi(o.value, Bool)
       end
     end
 
@@ -133,11 +137,13 @@ module Scale
         o = OptionU32.decode scale_bytes
         expect(o.value).to eql(nil)
         expect(o.encode).to eql('00')
+        parse_via_ffi(o.value, OptionU32)
 
         scale_bytes = Scale::Bytes.new('0x01ffffff00')
         o = OptionU32.decode scale_bytes
         expect(o.value.value).to eql(16_777_215)
         expect(o.encode).to eql('01ffffff00')
+        parse_via_ffi(o.value, OptionU32)
       end
 
       it 'can be construct form type string' do
@@ -146,6 +152,7 @@ module Scale
         o = type.decode scale_bytes
         expect(o.value.value).to eql(16_777_215)
         expect(o.encode).to eql('01ffffff00')
+        parse_via_ffi(o.value, OptionU32)
 
         scale_bytes = Scale::Bytes.new('0x010c003afe')
         type = type_of('Option<Vec<U8>>')

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,8 +1,24 @@
 # coding: utf-8
 require 'scale'
+require 'ffi'
 require_relative './types_for_test.rb'
 
 module Scale
+  module Rust
+    extend FFI::Library
+    ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
+    attach_function :vector_input, %i[pointer int], :int
+  end
+
+  vec = [7, 8, 9]
+  vec_c = FFI::MemoryPointer.new(:int, vec.size)
+  vec_c.write_array_of_int vec
+  describe do
+    it 'should return 1 regardless of input' do
+      expect(Rust.vector_input(vec_c, vec.size)).to eql(1)
+    end
+  end
+
   module Types
     describe U8 do
       it 'should work correctly' do

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,182 +1,184 @@
-require "scale"
-require_relative "./types_for_test.rb"
+# coding: utf-8
+require 'scale'
+require_relative './types_for_test.rb'
 
 module Scale
   module Types
     describe U8 do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x45")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x45')
+        puts scale_bytes
         o = U8.decode scale_bytes
         expect(o.value).to eql(69)
-        expect(o.encode).to eql("45")
+        expect(o.encode).to eql('45')
       end
     end
 
     describe U16 do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x2a00")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x2a00')
         o = U16.decode scale_bytes
         expect(o.value).to eql(42)
-        expect(o.encode).to eql("2a00")
+        expect(o.encode).to eql('2a00')
       end
     end
 
     describe U32 do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0xffffff00")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0xffffff00')
         o = U32.decode scale_bytes
-        expect(o.value).to eql(16777215)
-        expect(o.encode).to eql("ffffff00")
+        expect(o.value).to eql(16_777_215)
+        expect(o.encode).to eql('ffffff00')
       end
     end
 
     describe U64 do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x00e40b5403000000")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x00e40b5403000000')
         o = U64.decode scale_bytes
-        expect(o.value).to eql(14294967296)
-        expect(o.encode).to eql("00e40b5403000000")
+        expect(o.value).to eql(14_294_967_296)
+        expect(o.encode).to eql('00e40b5403000000')
       end
     end
 
     describe U128 do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0bfeffffffffffff0000000000000000")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0bfeffffffffffff0000000000000000')
         o = U128.decode scale_bytes
-        expect(o.value).to eql(18446744073709551115)
-        expect(o.encode).to eql("0bfeffffffffffff0000000000000000")
+        expect(o.value).to eql(18_446_744_073_709_551_115)
+        expect(o.encode).to eql('0bfeffffffffffff0000000000000000')
       end
     end
 
     describe Bool do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x00")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x00')
         o = Bool.decode scale_bytes
         expect(o.value).to eql(false)
-        expect(o.encode).to eql("00")
+        expect(o.encode).to eql('00')
 
-        scale_bytes = Scale::Bytes.new("0x01")
+        scale_bytes = Scale::Bytes.new('0x01')
         o = Bool.decode scale_bytes
         expect(o.value).to eql(true)
-        expect(o.encode).to eql("01")
+        expect(o.encode).to eql('01')
       end
     end
 
     describe Compact do
-      it "single-byte mode compact should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x00")
+      it 'single-byte mode compact should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x00')
         o = Compact.decode scale_bytes
         expect(o.value).to eql(0)
-        expect(o.encode).to eql("00")
+        expect(o.encode).to eql('00')
 
-        scale_bytes = Scale::Bytes.new("0x04")
+        scale_bytes = Scale::Bytes.new('0x04')
         o = Compact.decode scale_bytes
         expect(o.value).to eql(1)
-        expect(o.encode).to eql("04")
+        expect(o.encode).to eql('04')
 
-        scale_bytes = Scale::Bytes.new("0xa8")
+        scale_bytes = Scale::Bytes.new('0xa8')
         o = Compact.decode scale_bytes
         expect(o.value).to eql(42)
-        expect(o.encode).to eql("a8")
+        expect(o.encode).to eql('a8')
 
-        scale_bytes = Scale::Bytes.new("0xfc")
+        scale_bytes = Scale::Bytes.new('0xfc')
         o = Compact.decode scale_bytes
         expect(o.value).to eql(63)
-        expect(o.encode).to eql("fc")
+        expect(o.encode).to eql('fc')
       end
 
-      it "two-byte mode compact should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x1501")
+      it 'two-byte mode compact should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x1501')
         o = Compact.decode scale_bytes
         expect(o.value).to eql(69)
-        expect(o.encode).to eql("1501")
+        expect(o.encode).to eql('1501')
       end
 
-      it "four-byte mode compact should work correctly" do
-        scale_bytes = Scale::Bytes.new("0xfeffffff")
+      it 'four-byte mode compact should work correctly' do
+        scale_bytes = Scale::Bytes.new('0xfeffffff')
         o = Compact.decode scale_bytes
-        expect(o.value).to eql(1073741823)
-        expect(o.encode).to eql("feffffff")
+        expect(o.value).to eql(1_073_741_823)
+        expect(o.encode).to eql('feffffff')
       end
 
-      it "big-integer mode compact should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0300000040")
+      it 'big-integer mode compact should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0300000040')
         o = Compact.decode scale_bytes
-        expect(o.value).to eql(1073741824)
-        expect(o.encode).to eql("0300000040")
+        expect(o.value).to eql(1_073_741_824)
+        expect(o.encode).to eql('0300000040')
       end
     end
 
     describe Option do
-      it "option bool should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x00")
+      it 'option bool should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x00')
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(nil)
-        expect(o.encode).to eql("00")
+        expect(o.encode).to eql('00')
 
-        scale_bytes = Scale::Bytes.new("0x01")
+        scale_bytes = Scale::Bytes.new('0x01')
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(false)
-        expect(o.encode).to eql("01")
+        expect(o.encode).to eql('01')
 
-        scale_bytes = Scale::Bytes.new("0x02")
+        scale_bytes = Scale::Bytes.new('0x02')
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(true)
-        expect(o.encode).to eql("02")
+        expect(o.encode).to eql('02')
       end
 
-      it "option u32 should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x00")
+      it 'option u32 should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x00')
         o = OptionU32.decode scale_bytes
         expect(o.value).to eql(nil)
-        expect(o.encode).to eql("00")
+        expect(o.encode).to eql('00')
 
-        scale_bytes = Scale::Bytes.new("0x01ffffff00")
+        scale_bytes = Scale::Bytes.new('0x01ffffff00')
         o = OptionU32.decode scale_bytes
-        expect(o.value.value).to eql(16777215)
-        expect(o.encode).to eql("01ffffff00")
+        expect(o.value.value).to eql(16_777_215)
+        expect(o.encode).to eql('01ffffff00')
       end
 
-      it "can be construct form type string" do
-        scale_bytes = Scale::Bytes.new("0x01ffffff00")
-        type = type_of("Option<U32>")
+      it 'can be construct form type string' do
+        scale_bytes = Scale::Bytes.new('0x01ffffff00')
+        type = type_of('Option<U32>')
         o = type.decode scale_bytes
-        expect(o.value.value).to eql(16777215)
-        expect(o.encode).to eql("01ffffff00")
+        expect(o.value.value).to eql(16_777_215)
+        expect(o.encode).to eql('01ffffff00')
 
-        scale_bytes = Scale::Bytes.new("0x010c003afe")
-        type = type_of("Option<Vec<U8>>")
+        scale_bytes = Scale::Bytes.new('0x010c003afe')
+        type = type_of('Option<Vec<U8>>')
         o = type.decode scale_bytes
         expect(o.value.value.map(&:value)).to eql([0, 58, 254])
-        expect(o.encode).to eql("010c003afe")
+        expect(o.encode).to eql('010c003afe')
 
-        scale_bytes = Scale::Bytes.new("0x0c0100013a01fe")
-        type = type_of("Vec<Option<U8>>")
+        scale_bytes = Scale::Bytes.new('0x0c0100013a01fe')
+        type = type_of('Vec<Option<U8>>')
         o = type.decode scale_bytes
-        expect(o.value.map do |e| e.value.value end).to eql([0, 58, 254])
-        expect(o.encode).to eql("0c0100013a01fe")
+        expect(o.value.map { |e| e.value.value }).to eql([0, 58, 254])
+        expect(o.encode).to eql('0c0100013a01fe')
       end
     end
 
     describe Vec do
-      it "vector u8 should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0c003afe")
+      it 'vector u8 should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0c003afe')
         o = VecU8.decode scale_bytes
         expect(o.value.map(&:value)).to eql([0, 58, 254])
-        expect(o.encode).to eql("0c003afe")
+        expect(o.encode).to eql('0c003afe')
       end
 
-      it "Vec<U8> should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0c003afe")
-        o = type_of("Vec<U8>").decode scale_bytes
+      it 'Vec<U8> should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0c003afe')
+        o = type_of('Vec<U8>').decode scale_bytes
         expect(o.value.map(&:value)).to eql([0, 58, 254])
-        expect(o.encode).to eql("0c003afe")
+        expect(o.encode).to eql('0c003afe')
       end
 
-      it "Vec<BalanceLock> should work correctly" do
+      it 'Vec<BalanceLock> should work correctly' do
         # scale_bytes = Scale::Bytes.new("0x0876657374696e67207326160de7075e035823000000000000017374616b696e67208018179741946c6630a039000000000002")
-        scale_bytes = Scale::Bytes.new("0x0c7374616b696e6720a18161b5b58201000000000000000000ffffffff1f706872656c6563740030434cc42501000000000000000000ffffffff1e64656d6f63726163ffffffffffffffffffffffffffffffffc0c0150002")
-        o = type_of("Vec<BalanceLock>").decode scale_bytes
+        scale_bytes = Scale::Bytes.new('0x0c7374616b696e6720a18161b5b58201000000000000000000ffffffff1f706872656c6563740030434cc42501000000000000000000ffffffff1e64656d6f63726163ffffffffffffffffffffffffffffffffc0c0150002')
+        o = type_of('Vec<BalanceLock>').decode scale_bytes
         expect(o.value.length).to eql(3)
 
         first_balance_lock = o.value[0]
@@ -185,22 +187,22 @@ module Scale
 
         [
           [
-            [first_balance_lock.id, VecU8Length8, "staking "],
-            [first_balance_lock.amount, Balance, 425191920468385],
-            [first_balance_lock.until, U32, 4294967295],
-            [first_balance_lock.reasons, WithdrawReasons, ["TransactionPayment", "Transfer", "Reserve", "Fee", "Tip"]],
+            [first_balance_lock.id, VecU8Length8, 'staking '],
+            [first_balance_lock.amount, Balance, 425_191_920_468_385],
+            [first_balance_lock.until, U32, 4_294_967_295],
+            [first_balance_lock.reasons, WithdrawReasons, %w[TransactionPayment Transfer Reserve Fee Tip]]
           ],
           [
-            [second_balance_lock.id, VecU8Length8, "phrelect"],
-            [second_balance_lock.amount, Balance, 323000000000000],
-            [second_balance_lock.until, U32, 4294967295],
-            [second_balance_lock.reasons, WithdrawReasons, ["Transfer", "Reserve", "Fee", "Tip"]],
+            [second_balance_lock.id, VecU8Length8, 'phrelect'],
+            [second_balance_lock.amount, Balance, 323_000_000_000_000],
+            [second_balance_lock.until, U32, 4_294_967_295],
+            [second_balance_lock.reasons, WithdrawReasons, %w[Transfer Reserve Fee Tip]]
           ],
           [
-            [third_balance_lock.id, VecU8Length8, "democrac"],
-            [third_balance_lock.amount, Balance, 340282366920938463463374607431768211455],
-            [third_balance_lock.until, U32, 1425600],
-            [third_balance_lock.reasons, WithdrawReasons, ["Transfer"]],
+            [third_balance_lock.id, VecU8Length8, 'democrac'],
+            [third_balance_lock.amount, Balance, 340_282_366_920_938_463_463_374_607_431_768_211_455],
+            [third_balance_lock.until, U32, 1_425_600],
+            [third_balance_lock.reasons, WithdrawReasons, ['Transfer']]
           ]
         ].each do |item|
           item.each do |(actual_value, expectation_type, expectation_value)|
@@ -208,13 +210,13 @@ module Scale
             expect(actual_value.value).to eql(expectation_value)
           end
         end
-        expect(o.encode).to eql("0c7374616b696e6720a18161b5b58201000000000000000000ffffffff1f706872656c6563740030434cc42501000000000000000000ffffffff1e64656d6f63726163ffffffffffffffffffffffffffffffffc0c0150002")
+        expect(o.encode).to eql('0c7374616b696e6720a18161b5b58201000000000000000000ffffffff1f706872656c6563740030434cc42501000000000000000000ffffffff1e64656d6f63726163ffffffffffffffffffffffffffffffffc0c0150002')
       end
     end
 
     describe Struct do
-      it "Student should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0100000045000045")
+      it 'Student should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0100000045000045')
         o = Student.decode scale_bytes
 
         [
@@ -233,110 +235,110 @@ module Scale
         ]
           .map { |(actual, expectation)| expect(actual.value).to eql(expectation) }
 
-        expect(o.encode).to eql("0100000045000045")
+        expect(o.encode).to eql('0100000045000045')
       end
     end
 
     describe Tuple do
-      it "should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x4545")
+      it 'should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x4545')
         o = TupleDoubleU8.decode scale_bytes
         expect(o.value.map(&:value)).to eql([69, 69])
-        expect(o.encode).to eql("4545")
+        expect(o.encode).to eql('4545')
       end
 
-      it "can be typed from type string" do
-        klass = type_of("(U8, U8)")
-        expect(klass.name.start_with?("Tuple")).to be true
+      it 'can be typed from type string' do
+        klass = type_of('(U8, U8)')
+        expect(klass.name.start_with?('Tuple')).to be true
 
-        scale_bytes = Scale::Bytes.new("0x4545")
+        scale_bytes = Scale::Bytes.new('0x4545')
         o = klass.decode scale_bytes
         expect(o.value.map(&:value)).to eql([69, 69])
-        expect(o.encode).to eql("4545")
+        expect(o.encode).to eql('4545')
       end
     end
 
     describe Enum do
-      it "IntOrBool should work correctly" do
-        scale_bytes = Scale::Bytes.new("0x0101")
+      it 'IntOrBool should work correctly' do
+        scale_bytes = Scale::Bytes.new('0x0101')
         o = IntOrBool.decode scale_bytes
-        expect(o.encode).to eql("0101")
+        expect(o.encode).to eql('0101')
         expect(o.value.value).to eql(true)
 
-        scale_bytes = Scale::Bytes.new("0x002a")
+        scale_bytes = Scale::Bytes.new('0x002a')
         o = IntOrBool.decode scale_bytes
-        expect(o.encode).to eql("002a")
+        expect(o.encode).to eql('002a')
         expect(o.value.value).to eql(42)
       end
     end
 
     describe Set do
-      it "should work correctly" do
-        o = WithdrawReasons.decode Scale::Bytes.new("0x01")
-        expect(o.value).to eql(["TransactionPayment"])
-        expect(o.encode).to eql("01")
+      it 'should work correctly' do
+        o = WithdrawReasons.decode Scale::Bytes.new('0x01')
+        expect(o.value).to eql(['TransactionPayment'])
+        expect(o.encode).to eql('01')
 
-        o = WithdrawReasons.decode Scale::Bytes.new("0x03")
-        expect(o.value).to eql(["TransactionPayment", "Transfer"])
-        expect(o.encode).to eql("03")
+        o = WithdrawReasons.decode Scale::Bytes.new('0x03')
+        expect(o.value).to eql(%w[TransactionPayment Transfer])
+        expect(o.encode).to eql('03')
 
-        o = WithdrawReasons.decode Scale::Bytes.new("0x16")
-        expect(o.value).to eql(["Transfer", "Reserve", "Tip"])
-        expect(o.encode).to eql("16")
+        o = WithdrawReasons.decode Scale::Bytes.new('0x16')
+        expect(o.value).to eql(%w[Transfer Reserve Tip])
+        expect(o.encode).to eql('16')
       end
     end
 
     describe Bytes do
-      it "should work correctly when bytes are utf-8" do
-        o = Bytes.decode Scale::Bytes.new("0x14436166c3a9")
-        expect(o.value).to eql("Café")
-        expect(o.encode).to eql("14436166c3a9")
+      it 'should work correctly when bytes are utf-8' do
+        o = Bytes.decode Scale::Bytes.new('0x14436166c3a9')
+        expect(o.value).to eql('Café')
+        expect(o.encode).to eql('14436166c3a9')
       end
 
-      it "should work correctly when bytes are not utf-8" do
-        o = Bytes.decode Scale::Bytes.new("0x2cf6e6365010130543a3a416")
-        expect(o.value).to eql("0xf6e6365010130543a3a416")
-        expect(o.encode).to eql("2cf6e6365010130543a3a416")
+      it 'should work correctly when bytes are not utf-8' do
+        o = Bytes.decode Scale::Bytes.new('0x2cf6e6365010130543a3a416')
+        expect(o.value).to eql('0xf6e6365010130543a3a416')
+        expect(o.encode).to eql('2cf6e6365010130543a3a416')
       end
     end
 
     describe Address do
-      it "should work correctly" do
-        o = Address.decode Scale::Bytes.new("0xff0102030405060708010203040506070801020304050607080102030405060708")
-        expect(o.value).to eql("0x0102030405060708010203040506070801020304050607080102030405060708")
-        expect(o.encode).to eql("ff0102030405060708010203040506070801020304050607080102030405060708")
+      it 'should work correctly' do
+        o = Address.decode Scale::Bytes.new('0xff0102030405060708010203040506070801020304050607080102030405060708')
+        expect(o.value).to eql('0x0102030405060708010203040506070801020304050607080102030405060708')
+        expect(o.encode).to eql('ff0102030405060708010203040506070801020304050607080102030405060708')
 
-        o = Address.decode Scale::Bytes.new("0xfd11121314")
-        expect(o.value).to eql("0x11121314")
-        expect(o.encode).to eql("fd11121314")
+        o = Address.decode Scale::Bytes.new('0xfd11121314')
+        expect(o.value).to eql('0x11121314')
+        expect(o.encode).to eql('fd11121314')
 
-        o = Address.decode Scale::Bytes.new("0xfc0001")
-        expect(o.value).to eql("0x0001")
-        expect(o.encode).to eql("fc0001")
+        o = Address.decode Scale::Bytes.new('0xfc0001')
+        expect(o.value).to eql('0x0001')
+        expect(o.encode).to eql('fc0001')
 
-        o = Address.decode Scale::Bytes.new("0x01")
-        expect(o.value).to eql("0x01")
-        expect(o.encode).to eql("01")
+        o = Address.decode Scale::Bytes.new('0x01')
+        expect(o.value).to eql('0x01')
+        expect(o.encode).to eql('01')
       end
 
-      it "can encode to ss58" do
-        o = Address.decode Scale::Bytes.new("0xff0102030405060708010203040506070801020304050607080102030405060708")
-        expect(o.encode(true)).to eql("5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF")
-        expect(o.encode(true, 18)).to eql("2oCCJJEf7BBDyYSCp5WP2FPh72EYPXMDDmnoMZE8Y2FW8HLi")
+      it 'can encode to ss58' do
+        o = Address.decode Scale::Bytes.new('0xff0102030405060708010203040506070801020304050607080102030405060708')
+        expect(o.encode(true)).to eql('5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF')
+        expect(o.encode(true, 18)).to eql('2oCCJJEf7BBDyYSCp5WP2FPh72EYPXMDDmnoMZE8Y2FW8HLi')
       end
     end
 
     describe VecU8Length8 do
-      it "should work correctly with utf-8" do
-        o = VecU8Length8.decode Scale::Bytes.new("0x6162636465666768")
-        expect(o.value).to eql("abcdefgh")
-        expect(o.encode).to eql("6162636465666768")
+      it 'should work correctly with utf-8' do
+        o = VecU8Length8.decode Scale::Bytes.new('0x6162636465666768')
+        expect(o.value).to eql('abcdefgh')
+        expect(o.encode).to eql('6162636465666768')
       end
 
-      it "should work correctly with no utf-8" do
-        o = VecU8Length8.decode Scale::Bytes.new("0x374656d343041636")
-        expect(o.value).to eql("0x374656d343041636")
-        expect(o.encode).to eql("374656d343041636")
+      it 'should work correctly with no utf-8' do
+        o = VecU8Length8.decode Scale::Bytes.new('0x374656d343041636')
+        expect(o.value).to eql('0x374656d343041636')
+        expect(o.encode).to eql('374656d343041636')
       end
     end
   end

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -1,29 +1,13 @@
 # coding: utf-8
 require 'scale'
-require 'ffi'
 require_relative './types_for_test.rb'
 
 module Scale
-  module Rust
-    extend FFI::Library
-    ffi_lib 'target/debug/libvector_ffi.' + FFI::Platform::LIBSUFFIX
-    attach_function :vector_input, %i[pointer int], :int
-  end
-
-  vec = [7, 8, 9]
-  vec_c = FFI::MemoryPointer.new(:int, vec.size)
-  vec_c.write_array_of_int vec
-  describe do
-    it 'should return 1 regardless of input' do
-      expect(Rust.vector_input(vec_c, vec.size)).to eql(1)
-    end
-  end
-
   module Types
     describe U8 do
       it 'should work correctly' do
         scale_bytes = Scale::Bytes.new('0x45')
-        puts scale_bytes
+        # puts scale_bytes
         o = U8.decode scale_bytes
         expect(o.value).to eql(69)
         expect(o.encode).to eql('45')

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -120,16 +120,23 @@ module Scale
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(nil)
         expect(o.encode).to eql('00')
+        parse_via_ffi(o.value, OptionBool)
 
         scale_bytes = Scale::Bytes.new('0x01')
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(false)
         expect(o.encode).to eql('01')
+        # Rust SCALE does not implement Optional Booleans conformant to
+        # specification yet, so this is commented for now
+        # parse_via_ffi(o.value, OptionBool)
 
         scale_bytes = Scale::Bytes.new('0x02')
         o = OptionBool.decode scale_bytes
         expect(o.value).to eql(true)
         expect(o.encode).to eql('02')
+        # Rust SCALE does not implement Optional Booleans conformant to
+        # specification yet, so this is commented for now
+        # parse_via_ffi(o.value, OptionBool)
       end
 
       it 'option u32 should work correctly' do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,8 @@ pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, ex
     true
 }
 
+#[no_mangle]
+pub extern fn byte_string_literal_parse_u8(v_pointer: *const u8, len: usize, expectation: u8) -> bool {
+    assert_eq!(byte_string_literal_internal::<u8>(v_pointer, len), expectation);
+    true
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,11 @@ pub extern fn parse_u64(v_pointer: *const u8, len: usize, expectation: u64) {
 }
 
 #[no_mangle]
+pub extern fn parse_u32(v_pointer: *const u8, len: usize, expectation: u32) {
+    assert_eq!(decode_from_raw_parts::<u32>(v_pointer, len), expectation);
+}
+
+#[no_mangle]
 pub extern fn parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
     assert_eq!(decode_from_raw_parts::<u8>(v_pointer, len), expectation);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,20 @@ pub extern fn parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
 pub extern fn parse_bool(v_pointer: *const u8, len: usize, expectation: bool) {
     assert_eq!(decode_from_raw_parts::<bool>(v_pointer, len), expectation);
 }
+
+#[no_mangle]
+pub extern fn parse_opt_u32(v_pointer: *const u8, len: usize, inner_value: u32, option: bool) {
+    let expectation = match option {
+        true => Some(inner_value),
+        false => None,
+    };
+    println!("Expectation: {:?}", expectation);
+    assert_eq!(decode_from_raw_parts::<Option<u32>>(v_pointer, len), expectation);
+
+    let v = vec![1, 1];
+    println!("{:?}", <Option<bool>>::decode(&mut &v[..]));
+
+    // <Option<bool>>::encode
+    println!("{:?}", None::<Option<u64>>.encode());
+    println!("{:?}", Some(69u32).encode());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,8 @@ pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, ex
 pub extern fn byte_string_literal_parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
     assert_eq!(byte_string_literal_internal::<u8>(v_pointer, len), expectation);
 }
+
+#[no_mangle]
+pub extern fn byte_string_literal_parse_bool(v_pointer: *const u8, len: usize, expectation: bool) {
+    assert_eq!(byte_string_literal_internal::<bool>(v_pointer, len), expectation);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::slice;
 use parity_scale_codec::{Encode, Decode};
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize) -> bool {
+pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize, expectation: u64) -> bool {
     let data_slice = unsafe {
         assert!(!v_pointer.is_null());
         slice::from_raw_parts(v_pointer, len)
@@ -13,7 +13,7 @@ pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize) -> boo
     v.using_encoded(|ref slice| {
         println!("encoded slice: {:?}", slice);
     });
-    println!("{:?}", <u64>::decode(&mut &v[..]).unwrap());
+    assert_eq!(<u64>::decode(&mut &v[..]).unwrap(), expectation);
     true
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,30 +2,27 @@ extern crate parity_scale_codec;
 use std::slice;
 use parity_scale_codec::{Encode, Decode};
 
-fn byte_string_literal_internal<T: Decode + PartialEq + std::fmt::Debug>(v_pointer: *const u8, len: usize) -> T {
+fn decode_from_raw_parts<T: Decode + PartialEq + std::fmt::Debug>(v_pointer: *const u8, len: usize) -> T {
     let data_slice = unsafe {
         assert!(!v_pointer.is_null());
         slice::from_raw_parts(v_pointer, len)
     };
     let v = data_slice.to_vec();
     println!("vector is {:?}", v);
-    v.using_encoded(|ref slice| {
-        println!("encoded slice: {:?}", slice);
-    });
     <T>::decode(&mut &v[..]).unwrap()
 }
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, expectation: u64) {
-    assert_eq!(byte_string_literal_internal::<u64>(v_pointer, len), expectation);
+pub extern fn parse_u64(v_pointer: *const u8, len: usize, expectation: u64) {
+    assert_eq!(decode_from_raw_parts::<u64>(v_pointer, len), expectation);
 }
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
-    assert_eq!(byte_string_literal_internal::<u8>(v_pointer, len), expectation);
+pub extern fn parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
+    assert_eq!(decode_from_raw_parts::<u8>(v_pointer, len), expectation);
 }
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse_bool(v_pointer: *const u8, len: usize, expectation: bool) {
-    assert_eq!(byte_string_literal_internal::<bool>(v_pointer, len), expectation);
+pub extern fn parse_bool(v_pointer: *const u8, len: usize, expectation: bool) {
+    assert_eq!(decode_from_raw_parts::<bool>(v_pointer, len), expectation);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,19 @@
+extern crate parity_scale_codec;
 use std::slice;
+use parity_scale_codec::{Encode, Decode};
 
 #[no_mangle]
-pub extern fn vector_input(v_pointer: *const u8, len: usize) -> u32 {
-    println!("pointer is {:?}", v_pointer);
+pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize) -> bool {
     let data_slice = unsafe {
         assert!(!v_pointer.is_null());
         slice::from_raw_parts(v_pointer, len)
     };
     let v = data_slice.to_vec();
     println!("vector is {:?}", v);
-    1
+    v.using_encoded(|ref slice| {
+        println!("encoded slice: {:?}", slice);
+    });
+    println!("{:?}", <u64>::decode(&mut &v[..]).unwrap());
+    true
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,15 @@ pub extern fn parse_opt_u32(v_pointer: *const u8, len: usize, inner_value: u32, 
     assert_eq!(decode_from_raw_parts::<Option<u32>>(v_pointer, len), expectation);
 }
 
+#[no_mangle]
+pub extern fn parse_opt_bool(v_pointer: *const u8, len: usize, inner_value: bool, option: bool) {
+    let expectation = match option {
+        true => Some(inner_value),
+        false => None,
+    };
+    assert_eq!(decode_from_raw_parts::<Option<bool>>(v_pointer, len), expectation);
+}
+
 #[test]
 fn opt_bool_is_broken()
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate parity_scale_codec;
 use std::slice;
-use parity_scale_codec::{Encode, Decode};
+use parity_scale_codec::{Decode};
 
 fn decode_from_raw_parts<T: Decode + PartialEq + std::fmt::Debug>(v_pointer: *const u8, len: usize) -> T {
     let data_slice = unsafe {
@@ -38,7 +38,28 @@ pub extern fn parse_opt_u32(v_pointer: *const u8, len: usize, inner_value: u32, 
         false => None,
     };
     assert_eq!(decode_from_raw_parts::<Option<u32>>(v_pointer, len), expectation);
+}
 
+#[test]
+fn opt_bool_is_broken()
+{
+    // does not conform to boolean specification in https://substrate.dev/docs/en/conceptual/core/codec#options
     let v = vec![1, 1];
+    assert_eq!(<Option<bool>>::decode(&mut &v[..]).unwrap(), Some(true));
 
+    //this does
+    let v = vec![0];
+    assert_eq!(<Option<bool>>::decode(&mut &v[..]).unwrap(), None);
+
+    //this does not
+    let v = vec![0, 0, 0, 0];
+    assert_eq!(<Option<bool>>::decode(&mut &v[..]).unwrap(), None);
+
+    //this does not
+    let v = vec![1];
+    assert!(<Option<bool>>::decode(&mut &v[..]).is_err());
+
+    //this does not
+    let v = vec![2];
+    assert!(<Option<bool>>::decode(&mut &v[..]).is_err())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+use std::slice;
+
+#[no_mangle]
+pub extern fn vector_input(v_pointer: *const i32, len: usize) -> i32 {
+    println!("{:?}", v_pointer);
+    let data_slice = unsafe {
+        assert!(!v_pointer.is_null());
+        slice::from_raw_parts(v_pointer, len)
+    };
+    let v = data_slice.to_vec();
+    println!("{:?}", v);
+    1
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 use std::slice;
 
 #[no_mangle]
-pub extern fn vector_input(v_pointer: *const i32, len: usize) -> i32 {
-    println!("{:?}", v_pointer);
+pub extern fn vector_input(v_pointer: *const u8, len: usize) -> u32 {
+    println!("pointer is {:?}", v_pointer);
     let data_slice = unsafe {
         assert!(!v_pointer.is_null());
         slice::from_raw_parts(v_pointer, len)
     };
     let v = data_slice.to_vec();
-    println!("{:?}", v);
+    println!("vector is {:?}", v);
     1
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ fn decode_from_raw_parts<T: Decode + PartialEq + std::fmt::Debug>(v_pointer: *co
         slice::from_raw_parts(v_pointer, len)
     };
     let v = data_slice.to_vec();
-    println!("vector is {:?}", v);
     <T>::decode(&mut &v[..]).unwrap()
 }
 
@@ -38,13 +37,8 @@ pub extern fn parse_opt_u32(v_pointer: *const u8, len: usize, inner_value: u32, 
         true => Some(inner_value),
         false => None,
     };
-    println!("Expectation: {:?}", expectation);
     assert_eq!(decode_from_raw_parts::<Option<u32>>(v_pointer, len), expectation);
 
     let v = vec![1, 1];
-    println!("{:?}", <Option<bool>>::decode(&mut &v[..]));
 
-    // <Option<bool>>::encode
-    println!("{:?}", None::<Option<u64>>.encode());
-    println!("{:?}", Some(69u32).encode());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@ extern crate parity_scale_codec;
 use std::slice;
 use parity_scale_codec::{Encode, Decode};
 
-#[no_mangle]
-pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize, expectation: u64) -> bool {
+fn byte_string_literal_internal<T: Decode + PartialEq + std::fmt::Debug>(v_pointer: *const u8, len: usize) -> T {
     let data_slice = unsafe {
         assert!(!v_pointer.is_null());
         slice::from_raw_parts(v_pointer, len)
@@ -13,7 +12,12 @@ pub extern fn byte_string_literal_parse(v_pointer: *const u8, len: usize, expect
     v.using_encoded(|ref slice| {
         println!("encoded slice: {:?}", slice);
     });
-    assert_eq!(<u64>::decode(&mut &v[..]).unwrap(), expectation);
+    <T>::decode(&mut &v[..]).unwrap()
+}
+
+#[no_mangle]
+pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, expectation: u64) -> bool {
+    assert_eq!(byte_string_literal_internal::<u64>(v_pointer, len), expectation);
     true
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,11 @@ fn byte_string_literal_internal<T: Decode + PartialEq + std::fmt::Debug>(v_point
 }
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, expectation: u64) -> bool {
+pub extern fn byte_string_literal_parse_u64(v_pointer: *const u8, len: usize, expectation: u64) {
     assert_eq!(byte_string_literal_internal::<u64>(v_pointer, len), expectation);
-    true
 }
 
 #[no_mangle]
-pub extern fn byte_string_literal_parse_u8(v_pointer: *const u8, len: usize, expectation: u8) -> bool {
+pub extern fn byte_string_literal_parse_u8(v_pointer: *const u8, len: usize, expectation: u8) {
     assert_eq!(byte_string_literal_internal::<u8>(v_pointer, len), expectation);
-    true
 }


### PR DESCRIPTION
This adds [https://github.com/paritytech/parity-scale-codec.git]() as external reference during testing procedure to verify that both implementations are mutually consistent, and not merely self-consistent. 