### PR TITLE
Fix outdated Scale::TypeRegistry.instance.load call

### DIFF
--- a/spec/extrinsic_spec.rb
+++ b/spec/extrinsic_spec.rb
@@ -6,7 +6,7 @@ ROOT = Pathname.new File.expand_path("../../", __FILE__)
 module Scale::Types
   describe Extrinsic do
     before(:all) {
-      Scale::TypeRegistry.instance.load("kusama", 1045)
+      Scale::TypeRegistry.instance.load(spec_name: "kusama", custom_types: 1045)
       hex = File.open(File.join(ROOT, "spec", "metadata", "v10", "hex")).read.strip
       scale_bytes = Scale::Bytes.new(hex)
       metadata = Scale::Types::Metadata.decode scale_bytes


### PR DESCRIPTION
Was on old interface - has been updated to keyword arguments.